### PR TITLE
feat: handle rate limits

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -67,6 +68,10 @@ func issues(owner string, name string) ([]Issue, error) {
 
 		err := client.Query(context.Background(), &issuesQuery, variables)
 		if err != nil {
+			if strings.Contains(err.Error(), "abuse-rate-limits") {
+				time.Sleep(time.Minute)
+				continue
+			}
 			return nil, err
 		}
 		if len(issuesQuery.Repository.Issues.Edges) == 0 {

--- a/pr.go
+++ b/pr.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -58,6 +59,10 @@ func pullRequests(owner string, name string) ([]PullRequest, error) {
 
 		err := client.Query(context.Background(), &pullRequestsQuery, variables)
 		if err != nil {
+			if strings.Contains(err.Error(), "abuse-rate-limits") {
+				time.Sleep(time.Minute)
+				continue
+			}
 			return nil, err
 		}
 		if len(pullRequestsQuery.Repository.PullRequests.Edges) == 0 {

--- a/repos.go
+++ b/repos.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -32,6 +33,10 @@ func repository(owner string, name string) (Repo, error) {
 
 	err := client.Query(context.Background(), &repoQuery, variables)
 	if err != nil {
+		if strings.Contains(err.Error(), "abuse-rate-limits") {
+			time.Sleep(time.Minute)
+			return repository(owner, name)
+		}
 		return Repo{}, err
 	}
 
@@ -50,6 +55,10 @@ func repositories() ([]Repo, error) {
 
 		err := client.Query(context.Background(), &reposQuery, variables)
 		if err != nil {
+			if strings.Contains(err.Error(), "abuse-rate-limits") {
+				time.Sleep(time.Minute)
+				continue
+			}
 			return nil, err
 		}
 		if len(reposQuery.User.Repositories.Edges) == 0 {

--- a/users.go
+++ b/users.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -29,6 +31,10 @@ var viewerQuery struct {
 func getUsername() (string, error) {
 	err := client.Query(context.Background(), &viewerQuery, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "abuse-rate-limits") {
+			time.Sleep(time.Minute)
+			return getUsername()
+		}
 		return "", err
 	}
 
@@ -50,6 +56,10 @@ func followers() (int, error) {
 	}
 	err := client.Query(context.Background(), &followersQuery, variables)
 	if err != nil {
+		if strings.Contains(err.Error(), "abuse-rate-limits") {
+			time.Sleep(time.Minute)
+			return followers()
+		}
 		return 0, err
 	}
 


### PR DESCRIPTION
very poorly handle rate limits so we sleep 1m instead of exiting 1 right away...

unfortunatelly there seems to be no "correct way" of doing that on the graphql api (or at least I didn't find it)... this should be ok though I think...